### PR TITLE
#13 Sanitise all input to avoid vulnerabilities

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -72,15 +72,15 @@ class WorksAPI(Resource):  # pylint: disable=too-few-public-methods
         """
         filename = 'index.json'
         args = request.args
-        if args.get('page'):
-            filename = f'index_page_{args.get("page")}.json'
         try:
+            if args.get('page'):
+                filename = f'index_page_{int(args.get("page"))}.json'
             json_file_path = os.path.join(JSON_ROOT, 'works', filename)
             with open(json_file_path) as json_file:
                 return json.load(json_file)
-        except FileNotFoundError:
+        except (FileNotFoundError, ValueError):
             return {
-                abort(404, message='Works list doesn\'t exist, sorry.')
+                abort(404, message='That Works list doesn\'t exist, sorry.')
             }
 
 
@@ -93,11 +93,11 @@ class WorkAPI(Resource):  # pylint: disable=too-few-public-methods
         Returns the requested Work or a 404.
         """
         try:
-            json_file_path = os.path.join(JSON_ROOT, 'works', f'{work_id}.json')
+            json_file_path = os.path.join(JSON_ROOT, 'works', f'{int(work_id)}.json')
             with open(json_file_path) as json_file:
                 return json.load(json_file)
-        except FileNotFoundError:
-            return abort(404, message=f'Work {work_id} doesn\'t exist, sorry.')
+        except (FileNotFoundError, ValueError):
+            return abort(404, message='That Work doesn\'t exist, sorry.')
 
 
 class XOSAPI():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -113,7 +113,14 @@ def test_works_api_404():
             content_type='application/json',
         )
         assert response.status_code == 404
-        assert response.json['message'] == 'Works list doesn\'t exist, sorry.'
+        assert response.json['message'] == 'That Works list doesn\'t exist, sorry.'
+
+        response = client.get(
+            '/works/?page=!~*&-evil-text"',
+            content_type='application/json',
+        )
+        assert response.status_code == 404
+        assert response.json['message'] == 'That Works list doesn\'t exist, sorry.'
 
 
 @patch('builtins.open', mock_work())
@@ -142,7 +149,14 @@ def test_work_api_404():
             content_type='application/json',
         )
         assert response.status_code == 404
-        assert response.json['message'] == 'Work 2 doesn\'t exist, sorry.'
+        assert response.json['message'] == 'That Work doesn\'t exist, sorry.'
+
+        response = client.get(
+            '/works/!~*&-evil-text"/',
+            content_type='application/json',
+        )
+        assert response.status_code == 404
+        assert response.json['message'] == 'That Work doesn\'t exist, sorry.'
 
 
 @patch('requests.get', MagicMock(side_effect=mocked_requests_get))


### PR DESCRIPTION
Resolves #13

Sanitise all user input to avoid vulnerabilities.

Before this change any input by users was passed through to the functions to create a path, and also to open a file from the filesystem. So there's a chance that a curious person could try and make one of these functions do something we don't want.

To avoid this, I'm converting user input to an integer using Python's built in `int()` function. This means it will either cause an error, which we return a `404` for, or else converts it to a number which is then safe to use to return the JSON data file that corresponds to it.

### Acceptance Criteria
- [x] Sanitise `/works/?page=` input
- [x] Sanitise `/works/<id>/` input

### Relevant design files
* None

### Testing instructions
1. Start the API: `cd development` and `docker-compose up --build`
1. Try and break `/works/` with strange input. e.g. http://localhost:8081/works/?page=!#U^%$
1. Try and break `/works/<id>/` with strange input. e.g. http://localhost:8081/works/!#U^%$/

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
