### PR TITLE
#15 Add acknowledgement of country to root API response

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+skip=json

--- a/app/api.py
+++ b/app/api.py
@@ -49,6 +49,14 @@ class API(Resource):
         return {
             'hello': 'Welcome to the ACMI Public API.',
             'api': self.routes(),
+            'acknowledgement':
+                'ACMI acknowledges the Traditional Owners, the Wurundjeri and Boon Wurrung '
+                'people of the Kulin Nation, on whose land we meet, share and work. We pay our '
+                'respects to Elders past and present and extend our respect to Aboriginal and '
+                'Torres Strait Islander people from all nations of this land. Aboriginal and '
+                'Torres Strait Islander people should be aware that this website may contain '
+                'images, voices or names of deceased persons in photographs, film, audio '
+                'recordings or text.',
         }
 
     def routes(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -84,6 +84,7 @@ def test_api_root():
     api = API()
     assert api.get()['hello'] == 'Welcome to the ACMI Public API.'
     assert api.get()['api'] == ['/works/', '/works/<work_id>/']
+    assert 'ACMI acknowledges the Traditional Owners' in api.get()['acknowledgement']
 
 
 @patch('builtins.open', mock_index())


### PR DESCRIPTION
Resolves #15

Add acknowledgement of country to the root API response.

### Acceptance Criteria
- [x] Add acknowledgement of country to the root API response

### Relevant design files
* None

### Testing instructions
1. Run the API: `cd development` and `docker-compose up`
1. See the acknowledgement: http://localhost:8081

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
