### PR TITLE
#25 Fix production search index updater

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -274,6 +274,7 @@ class Search():
         except (
             elasticsearch.exceptions.RequestError,
             elasticsearch.exceptions.ConnectionTimeout,
+            elasticsearch.exceptions.ConnectionError,
         ) as exception:
             print(f'ERROR indexing {json_data.get("id")}: {exception}')
             return success
@@ -535,16 +536,16 @@ api.add_resource(WorkAPI, '/works/<work_id>/')
 api.add_resource(SearchAPI, '/search/')
 
 if __name__ == '__main__':
-    if DEBUG and UPDATE_WORKS:
-        print('===============================================')
-        print('Starting thread to update Works API from XOS...')
+    if UPDATE_WORKS:
+        print('========================================')
+        print('Starting to update Works API from XOS...')
         xos_private_api = XOSAPI()
         xos_private_api.get_works()
         xos_private_api.delete_works()
         search = Search()
         search.update_index(resource='works')
-        print('===============================================')
-    elif DEBUG and UPDATE_SEARCH:
+        print('========================================')
+    elif UPDATE_SEARCH:
         print('========================')
         print('Starting search indexing...')
         search = Search()

--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -15,11 +15,9 @@ if [ "$CRON_UPDATER" = "true" ]; then
     fi
 
     # Update API
-    export DEBUG=true
     export UPDATE_WORKS=true
     export XOS_API_ENDPOINT=https://xos.acmi.net.au/api/
     python -u -m app.api
-    export DEBUG=false
     export UPDATE_WORKS=false
 
     # Check for git changes


### PR DESCRIPTION
Resolves #25

Handle Elasticsearch connection errors, and remove the need for `DEBUG=true` so that the production updater connects to the production Elasticsearch instance instead of trying to reach `localhost:9200`.

### Acceptance Criteria
- [x] Handle Elasticsearch connection error gracefully
- [x] Remove need to use `DEBUG=true` for updating/indexing

### Relevant design files
* None

### Testing instructions
1. Set `DEBUG=false` and `UPDATE_SEARCH=true` in your `config.env`
1. Start just the api: `docker-compose -f docker-compose-base.yml up`
1. Run the search updater: `docker exec -it api python -u -m app.api`
1. **Note**: this will update the production search
1. Check the output to see each 1,000 records get indexed
1. Set `DEBUG=true` and `UPDATE_SEARCH=true` in your `config.env`
1. Start both search and api: `docker-compose up`
1. Note that your local search is indexed

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [ ] Changelog has been updated if necessary
