### PR TITLE
#34 Remove video_links that aren't on YouTube

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -523,6 +523,7 @@ class XOSAPI():
 
         if not INCLUDE_VIDEOS:
             self.remove_assets(work_json, 'videos')
+            self.remove_video_links(work_json)
 
         return work_json
 
@@ -567,6 +568,16 @@ class XOSAPI():
         if work_json.get('part_siblings'):
             for work in work_json.get('part_siblings'):
                 work.pop('thumbnail', None)
+
+    def remove_video_links(self, work_json):
+        """
+        Remove any video_links that aren't from YouTube until we negotiate
+        licensing with our partners.
+        """
+        if work_json.get('video_links'):
+            for idx, video_link in enumerate(work_json['video_links']):
+                if 'youtu' not in video_link.get('uri'):
+                    work_json['video_links'].pop(idx)
 
     def asset_exists(self, key):
         """

--- a/tests/data/100542.json
+++ b/tests/data/100542.json
@@ -77,7 +77,18 @@
     }
   ],
   "creators_other": [],
-  "video_links": [],
+  "video_links": [
+    {
+      "id":1,
+      "name":"Cent Mille Milliards de Poèmes",
+      "uri":"https://vimeo.com/19599227"
+    },
+    {
+      "id":2,
+      "name":"Launch Trailer",
+      "uri":"https://youtu.be/tCI396HyhbQ"
+      }
+  ],
   "media_note": null,
   "images": [
     {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -268,18 +268,24 @@ def test_update_assets():
             thumbnail_filename.replace('.1200x1200_q85.jpg', '')
         assert work_json_1['images'][0]['image_file_l'] == \
             thumbnail_filename.replace('1200x1200', '3840x3840')
+        assert work_json_1['video_links'][0]['uri'] == 'https://vimeo.com/19599227'
+        assert work_json_1['video_links'][1]['uri'] == 'https://youtu.be/tCI396HyhbQ'
 
         acmi_api.INCLUDE_IMAGES = True
         acmi_api.INCLUDE_VIDEOS = False
         work_json_2 = xos_private_api.update_assets(work_json)
         assert not work_json_2.get('thumbnail')
         assert work_json_2.get('images')
+        assert work_json_2['video_links'][0]['uri'] == 'https://youtu.be/tCI396HyhbQ'
+        assert len(work_json_2['video_links']) == 1
 
         acmi_api.INCLUDE_IMAGES = False
         acmi_api.INCLUDE_VIDEOS = False
         work_json_3 = xos_private_api.update_assets(work_json)
         assert not work_json_3.get('thumbnail')
         assert not work_json_3.get('images')
+        assert work_json_3['video_links'][0]['uri'] == 'https://youtu.be/tCI396HyhbQ'
+        assert len(work_json_3['video_links']) == 1
 
     with open('tests/data/111326.json', 'rb') as video:
         acmi_api.INCLUDE_IMAGES = True


### PR DESCRIPTION
Resolves #34

We have some `video_links` in our collection that are unlisted on the internet, and so we have to negotiate with our partners to see if we can export those on the API.

While we wait for confirmation, let's remove any that aren't YouTube links (all of our YouTube `video_links` are publicly searchable).

### Acceptance Criteria
- [x] Remove `video_links` that aren't on YouTube via the `INCLUDE_VIDEOS` environment variable

### Relevant design files
* None

### Testing instructions
1. Set `DEBUG=true`
1. Start the API: `cd development` and `docker-compose up`
1. Note there are vimeo.com `video_links`: http://localhost:8081/search/?query=vimeo.com
1. Set `DEBUG=true` and `UPDATE_WORKS=true` in your `config.env`
1. Start the API: `cd development` and `docker-compose up`
1. Once finished, note that there aren't any vimeo.com `video_links`: http://localhost:8081/search/?query=vimeo.com
1. Note there are YouTube `video_links`: http://localhost:8081/search/?query=youtu.be

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
