### PR TITLE
#41 Delete unpublished Works from the search index

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -284,6 +284,26 @@ class Search():
             print(f'ERROR indexing {json_data.get("id")}: {exception}')
             return success
 
+    def delete(self, resource, work_id):
+        """
+        Delete the search index for a single record.
+        """
+        success = False
+        try:
+            self.elastic_search.delete(
+                index=resource,
+                id=work_id,
+            )
+            success = True
+            return success
+        except (
+            elasticsearch.exceptions.RequestError,
+            elasticsearch.exceptions.ConnectionTimeout,
+            elasticsearch.exceptions.ConnectionError,
+        ) as exception:
+            print(f'ERROR deleting the index for {work_id}: {exception}')
+            return success
+
     def update_index(self, resource):
         """
         Update the search index for an API resource. e.g. 'works'
@@ -422,6 +442,7 @@ class XOSAPI():
         resource = 'works'
         params = self.params
         params['unpublished'] = True
+        elastic_search = Search()
         if ALL_WORKS:
             print('Deleting all unpublished XOS Works...')
         else:
@@ -450,6 +471,8 @@ class XOSAPI():
                     f'Error: couldn\'t delete {exception.filename} '
                     f'with error: {exception.strerror}'
                 )
+            # Remove the Work from the search index
+            elastic_search.delete(resource, work_id)
 
         print(f'Finished deleting {works_deleted}/{len(work_ids_to_delete)} {resource}.')
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -240,11 +240,27 @@ def test_delete_works(tmp_path):
     assert os.path.isfile(acmi_api.JSON_ROOT / 'works/index_page_2.json')
     assert os.path.isfile(acmi_api.JSON_ROOT / 'works/1.json')
     assert os.path.isfile(acmi_api.JSON_ROOT / 'works/2.json')
-    xos_private_api.delete_works()
-    assert os.path.isfile(acmi_api.JSON_ROOT / 'works/index.json')
-    assert os.path.isfile(acmi_api.JSON_ROOT / 'works/index_page_2.json')
-    assert os.path.isfile(acmi_api.JSON_ROOT / 'works/1.json')
-    assert not os.path.isfile(acmi_api.JSON_ROOT / 'works/2.json')
+    with patch('elasticsearch.Elasticsearch.delete', MagicMock()) as mock_search_delete:
+        xos_private_api.delete_works()
+        assert os.path.isfile(acmi_api.JSON_ROOT / 'works/index.json')
+        assert os.path.isfile(acmi_api.JSON_ROOT / 'works/index_page_2.json')
+        assert os.path.isfile(acmi_api.JSON_ROOT / 'works/1.json')
+        assert not os.path.isfile(acmi_api.JSON_ROOT / 'works/2.json')
+        assert mock_search_delete.call_args[1]['index'] == 'works'
+        assert mock_search_delete.call_args[1]['id'] == '2'
+
+    search_delete_error = elasticsearch.exceptions.ConnectionError()
+    search_delete_error.args = (500, 'Error', {})
+    with patch(
+        'elasticsearch.Elasticsearch.delete',
+        MagicMock(
+            side_effect=search_delete_error,
+        ),
+    ) as mock_search_delete:
+        xos_private_api.get_works()
+        assert os.path.isfile(acmi_api.JSON_ROOT / 'works/2.json')
+        xos_private_api.delete_works()
+        assert not os.path.isfile(acmi_api.JSON_ROOT / 'works/2.json')
 
 
 @patch('app.api.s3_resource.Object', MagicMock(side_effect=mock_boto3))


### PR DESCRIPTION
Resolves #41

When deleting unpublished Works metadata from the filesystem, also delete it from the search index.

### Acceptance Criteria
- [x] Delete unpublished Works from the elasitcsearch index
- [x] Re-create the `production` search index

### Relevant design files
* None

### Testing instructions
1. Start your environment: `cd development` and `docker-compose up`
1. Find a record that's indexed locally: http://localhost:8081/search/?query=xos
1. Manually delete it: `docker exec -it api ash` and `python3` and `from app.api import Search` and `Search().delete('works', 'id')`
1. Note that it no longer appears in search results: http://localhost:8081/search/?query=xos

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
