### PR TITLE
#40 Fix XOSAPI default params mutation bug

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -330,7 +330,7 @@ class XOSAPI():
         """
         endpoint = os.path.join(self.uri, f'{resource}/')
         if not params:
-            params = self.params
+            params = self.params.copy()
         retries = 0
         while retries < 3:
             try:
@@ -351,7 +351,7 @@ class XOSAPI():
         Download and save Works from XOS.
         """
         resource = 'works'
-        params = self.params
+        params = self.params.copy()
         if ALL_WORKS:
             print('Downloading all XOS Works... this will take a while')
         else:
@@ -420,7 +420,7 @@ class XOSAPI():
         Delete unpublished Works from the file system.
         """
         resource = 'works'
-        params = self.params
+        params = self.params.copy()
         params['unpublished'] = True
         if ALL_WORKS:
             print('Deleting all unpublished XOS Works...')
@@ -458,7 +458,7 @@ class XOSAPI():
         Download and save all Works list pages from XOS.
         """
         print(f'Saving all {resource} list index files...')
-        params = self.params
+        params = self.params.copy()
         params['page'] = 1
         while True:
             works_json = self.get(resource, params).json()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -247,6 +247,25 @@ def test_delete_works(tmp_path):
     assert not os.path.isfile(acmi_api.JSON_ROOT / 'works/2.json')
 
 
+@patch('requests.get', MagicMock(side_effect=mocked_requests_get))
+@patch('app.api.s3_resource.Object', MagicMock(side_effect=mock_boto3))
+def test_xos_api_params():
+    """
+    Test the default XOSAPI params aren't mutated by method calls.
+    """
+    params = {
+        'page_size': 10,
+        'unpublished': False,
+        'external': False,
+    }
+    xos_private_api = XOSAPI()
+    assert xos_private_api.params == params
+    xos_private_api.get_works()
+    assert xos_private_api.params == params
+    xos_private_api.delete_works()
+    assert xos_private_api.params == params
+
+
 @patch('app.api.s3_resource.Object', MagicMock(side_effect=mock_boto3))
 @patch('app.api.destination_bucket', MagicMock())
 def test_update_assets():


### PR DESCRIPTION
Resolves #40

While refactoring the XOSAPI class, I managed to introduce a bug that mutated the default params. This PR fixes that.

### Acceptance Criteria
- [x] Nightly update runs and updates Works index pages correctly

### Relevant design files
* None

### Testing instructions
Testing this completely requires running an update which takes a long time (~3 hours). So you can either:
1. Revert the changes to `api.py` by removing `.copy()` references
1. Run the tests to see them fail (the default params were mutated to include `date_modified__gte`): `docker exec -it api make test`

or

1. Start the base environment: `cd development` and `docker-compose -f docker-compose-base.yml up`
1. Run an update: `docker exec -it api ash` and `UPDATE_WORKS=true python -u -m app.api`
1. After the run has complete, note that the `/works/` index page shows the full `42664` works: http://localhost:8081/works/

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
