### PR TITLE
#44 Handle attempts to delete elasticsearch records that have already been deleted

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -300,6 +300,7 @@ class Search():
             elasticsearch.exceptions.RequestError,
             elasticsearch.exceptions.ConnectionTimeout,
             elasticsearch.exceptions.ConnectionError,
+            elasticsearch.exceptions.NotFoundError,
         ) as exception:
             print(f'ERROR deleting the index for {work_id}: {exception}')
             return success

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -262,6 +262,17 @@ def test_delete_works(tmp_path):
         xos_private_api.delete_works()
         assert not os.path.isfile(acmi_api.JSON_ROOT / 'works/2.json')
 
+    search_delete_error = elasticsearch.exceptions.NotFoundError()
+    search_delete_error.args = (404, 'NotFoundError', {})
+    with patch(
+        'elasticsearch.Elasticsearch.delete',
+        MagicMock(
+            side_effect=search_delete_error,
+        ),
+    ) as mock_search_delete:
+        xos_private_api.delete_works()
+        assert not os.path.isfile(acmi_api.JSON_ROOT / 'works/2.json')
+
 
 @patch('requests.get', MagicMock(side_effect=mocked_requests_get))
 @patch('app.api.s3_resource.Object', MagicMock(side_effect=mock_boto3))


### PR DESCRIPTION
Resolves #44

Handle attempts to delete elasticsearch records that have already been deleted and so return a `404` from elasticsearch.

### Acceptance Criteria
- [x] Handle `elasticsearch.exceptions.NotFoundError` errors gracefully when attempting to remove `unpublished` Works index records

### Relevant design files
* None

### Testing instructions
1. Start your environment: `docker-compose up`
1. Run a python shell: `docker exec -it api python`
1. Try deleting a search record that doesn't exist: `from app.api import Search` and `Search().delete('works', '1')`
1. Note that it returns `False` and doesn't throw an exception

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
