### PR TITLE
#46 Add a link to the deprecated Collections TSV file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This repository contains a full archive of ACMI collection metadata in TSV (tab 
 
 Find them at: `/app/tsv/`
 
+The [2017 collections TSV](https://github.com/ACMILabs/collection/blob/master/src/collections_data.tsv) can be found in the deprecated repository: [github.com/ACMILabs/collection](https://github.com/ACMILabs/collection)
+
 ### Assets
 
 Image and video assets will be found in the public S3 bucket when we have arranged suitable licenses with our partners: `s3://acmi-public-api`


### PR DESCRIPTION
Resolves #46

As a researcher I'd like to be able to compare TSV fields with old ACMI Collection data.

### Acceptance Criteria
- [x] Add a link to [collections_data.tsv](https://github.com/ACMILabs/collection/blob/master/src/collections_data.tsv) on the ACMI Public API readme

### Relevant design files
* None

### Testing instructions
1. Check the links work and the language sounds okay

### DoD
For requester to complete:
- [x] All acceptance criteria are met
~- [ ] New logic has been documented~
~- [ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
