### PR TITLE
#48 Upgrade elasticsearch development container to v7.16.1

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         condition: service_healthy
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.1
     hostname: api-search
     container_name: api-search
     restart: on-failure


### PR DESCRIPTION
Resolves #48

Upgrade elasticsearch development container to `v7.16.1`

### Acceptance Criteria
- [x] Upgrade `elasticsearch` development container to `v7.16.1`

### Relevant design files
* None

### Testing instructions
1. Build the development environment `docker-compose up --build`
1. Check the search still returns expected results: http://localhost:8081/search/?query=xos

### DoD
For requester to complete:
- [x] All acceptance criteria are met
~- [ ] New logic has been documented~
~- [ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
