### PR TITLE
#50 Update deprecated --dry-run argument from true to client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Dry-run deploy to ${{ env.DEPLOY_TAG }}
         if: success()
-        run: kubectl apply --namespace=${K8S_ENV} -f kubernetes/api.yml --dry-run=true
+        run: kubectl apply --namespace=${K8S_ENV} -f kubernetes/api.yml --dry-run=client
 
       - name: Deploy to ${{ env.DEPLOY_TAG }}
         if: success()
@@ -152,7 +152,7 @@ jobs:
 
       - name: Dry-run deploy to ${{ env.DEPLOY_TAG }}
         if: success()
-        run: kubectl apply --namespace=${K8S_ENV} -f kubernetes/api.yml --dry-run=true
+        run: kubectl apply --namespace=${K8S_ENV} -f kubernetes/api.yml --dry-run=client
 
       - name: Deploy to ${{ env.DEPLOY_TAG }}
         if: success()


### PR DESCRIPTION
Resolves #50

Fix deprecated dry-run argument in kubectl command.

### Acceptance Criteria
- [x] Update `--dry-run=true` to `--dry-run=client`

### Relevant design files
* None

### Testing instructions
1. Replace `BUILD_NUMBER` with `681db02973c9fdb0324f46df8cde80081aaf97ca` in `kubernetes/api.yml`
1. Try a dry run: `kubectl apply --namespace=xos-api-stg -f kubernetes/api.yml --dry-run=client`

### DoD
For requester to complete:
- [x] All acceptance criteria are met
~- [ ] New logic has been documented~
~- [ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
