### PR TITLE
#54 Update Elasticsearch error syntax to v8

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -212,7 +212,10 @@ class Search():
                     field: query
                 }
             }
-            search_results = self.elastic_search.search(index=resource, body=query_body)
+            search_results = self.elastic_search.search(  # pylint: disable=unexpected-keyword-arg
+                index=resource,
+                body=query_body,
+            )
         else:
             search_results = self.elastic_search.search(  # pylint: disable=unexpected-keyword-arg
                 index=resource,
@@ -269,7 +272,7 @@ class Search():
             except KeyError:
                 pass
         try:
-            self.elastic_search.index(
+            self.elastic_search.index(  # pylint: disable=unexpected-keyword-arg,missing-kwoa
                 index=resource,
                 id=json_data.get('id'),
                 body=json_data,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -85,13 +85,13 @@ def mock_search(index=None, body=None, q=None, params=None):  # pylint: disable=
     Mock Elasticsearch responses.
     """
     if q == '404':
-        raise elasticsearch.exceptions.NotFoundError
+        raise elasticsearch.exceptions.NotFoundError(message='', meta=MagicMock(), body='')
     if q == '400':
-        raise elasticsearch.exceptions.RequestError
+        raise elasticsearch.exceptions.RequestError(message='', meta=MagicMock(), body={})
     if q == '503':
-        raise elasticsearch.exceptions.ConnectionError
+        raise elasticsearch.exceptions.ConnectionError(message='')
     if q == '504':
-        raise elasticsearch.exceptions.ConnectionTimeout
+        raise elasticsearch.exceptions.ConnectionTimeout(message='')
     if q and not body:
         with open(
             f'tests/data/search_{index}_{q}_{params["size"]}_{params["from"]}.json',
@@ -106,7 +106,7 @@ def mock_search(index=None, body=None, q=None, params=None):  # pylint: disable=
             'rb',
         ) as json_file:
             return json.loads(json_file.read())
-    raise elasticsearch.exceptions.NotFoundError
+    raise elasticsearch.exceptions.NotFoundError(message='', meta=MagicMock(), body='')
 
 
 def test_api_root():
@@ -249,7 +249,7 @@ def test_delete_works(tmp_path):
         assert mock_search_delete.call_args[1]['index'] == 'works'
         assert mock_search_delete.call_args[1]['id'] == '2'
 
-    search_delete_error = elasticsearch.exceptions.ConnectionError()
+    search_delete_error = elasticsearch.exceptions.ConnectionError(message='')
     search_delete_error.args = (500, 'Error', {})
     with patch(
         'elasticsearch.Elasticsearch.delete',
@@ -262,7 +262,11 @@ def test_delete_works(tmp_path):
         xos_private_api.delete_works()
         assert not os.path.isfile(acmi_api.JSON_ROOT / 'works/2.json')
 
-    search_delete_error = elasticsearch.exceptions.NotFoundError()
+    search_delete_error = elasticsearch.exceptions.NotFoundError(
+        message='',
+        meta=MagicMock(),
+        body={},
+    )
     search_delete_error.args = (404, 'NotFoundError', {})
     with patch(
         'elasticsearch.Elasticsearch.delete',


### PR DESCRIPTION
Resolves #54

Elasticsearch and pylint were failing the lint/test steps in the build.

### Acceptance Criteria
- [x] Update syntax to satisfy pylint

### Relevant design files
* None

### Testing instructions
1. Run linting and testing: `cd development` and `docker-compose -f docker-compose-base.yml up` and `docker exec -it api make linttest`

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
