### PR TITLE
#56 Pin elasticsearch to v7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,4 +6,4 @@ gunicorn
 pytz
 requests
 sentry-sdk[flask]
-elasticsearch
+elasticsearch>=7.16,<8


### PR DESCRIPTION
Resolves #56

Pin elasticsearch to v7 to avoid the failing build.

### Acceptance Criteria
- [x] Pin `elasticsearch` to version 7

### Relevant design files
* None

### Testing instructions
1. See this build passes
1. See the search still works locally: `cd development` and `docker-compose up --build` and http://localhost:8081/search/?query=xos

### DoD
For requester to complete:
- [x] All acceptance criteria are met
~- [ ] New logic has been documented~
~- [ ] New logic has appropriate unit tests~
~- [ ] Changelog has been updated if necessary~
- [ ] Deployment / migration instruction have been updated if required
