### PR TITLE
#59 Add missing fields to the TSV exporter

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -709,6 +709,8 @@ class XOSAPI():
                 'production_places',
                 'production_dates',
                 'labels',
+                'eaas_environment_id',
+                'external_references',
             ])
 
             files_written = 0
@@ -766,6 +768,10 @@ class XOSAPI():
                             self.keys_from_dicts('name', json_data.get('production_places')),
                             self.keys_from_dicts('date', json_data.get('production_dates')),
                             self.strings_from_list(json_data.get('labels')),
+                            json_data.get('eaas_environment_id'),
+                            self.external_references_to_string(
+                                json_data.get('external_references')
+                            ),
                         ])
                         files_written += 1
                 if files_written % 1000 == 0:
@@ -796,6 +802,18 @@ class XOSAPI():
         """
         try:
             return ','.join(str(label) for label in your_list)
+        except TypeError:
+            return ''
+
+    def external_references_to_string(self, external_references):
+        """
+        Return a comma separated string of tuples from a list of external references.
+        """
+        try:
+            return ','.join([
+                f'({reference["source"]["name"]},{reference["source_identifier"]})'
+                for reference in external_references
+            ])
         except TypeError:
             return ''
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -536,7 +536,7 @@ def test_generate_tsv(tmp_path):
     with open(f'{acmi_api.TSV_ROOT}/data.tsv', encoding='utf-8') as tsv_file:
         reader = csv.reader(tsv_file, delimiter='\t')
         header = next(reader)
-        assert len(header) == 47
+        assert len(header) == 49
         assert header[0] == 'id'
         row_count = 0
         for _ in reader:
@@ -594,6 +594,32 @@ def test_strings_from_list():
     your_list = [1, 2, 7, 9]
     string = XOSAPI().strings_from_list(your_list)
     assert string == '1,2,7,9'
+    string = XOSAPI().strings_from_list(666)
+    assert string == ''
+
+
+def test_external_references_to_string():
+    """
+    Test the external_references_to_string method returns the correct data.
+    """
+    external_references = [
+        {
+            'source': {
+                'name': 'Wikidata',
+                'slug': 'wikidata',
+            },
+            'source_identifier': 'Q101096725',
+        },
+        {
+            'source': {
+                'name': 'TMDB-TV',
+                'slug': 'tmdb-tv',
+            },
+            'source_identifier': '95396',
+        },
+    ]
+    string = XOSAPI().external_references_to_string(external_references)
+    assert string == '(Wikidata,Q101096725),(TMDB-TV,95396)'
     string = XOSAPI().strings_from_list(666)
     assert string == ''
 


### PR DESCRIPTION
Resolves #59

The spreadsheet exporter requires fields to have custom logic for them to be exported in a useful format. Let's add the recently added XOS Works API fields.

### Acceptance Criteria
- [x] Add `eaas_environment_id` to the TSV exporter
- [x] Add `external_references` to the TSV exporter

### Relevant design files
* None

### Testing instructions
1. Start your environment: `cd development` and `docker-compose -f docker-compose-base.yml up`
1. Re-create the TSV and note the two new fields added to the end of `app/tsv/works.tsv`

```bash
$ docker exec -it api ash
$ python
> from app.api import XOSAPI
> x = XOSAPI()
> x.generate_tsv('works')
```

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
