### PR TITLE
#53 Updater fails switching to main branch

### DIFF
--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -10,6 +10,7 @@ if [ "$CRON_UPDATER" = "true" ]; then
     if [ "$DRY_RUN" = "true" ]; then
         echo "DRY_RUN Not checking out main branch..."
     else
+        git pull
         git checkout main
         git pull
     fi


### PR DESCRIPTION
Resolves #53

When the updater attempts to run it sometimes fails because it doesn't have the `main` branch in its local clone.

### Acceptance Criteria
- [x] Git pull before switching branches so the local clone has the `main` branch

### Relevant design files
* None

### Testing instructions
1. Ash into the staging pod: `kubectl exec -it -n xos-api-stg xos-api-78b47b6f8-cxw4g ash`
1. Note that you can't `git checkout main`
1. Run `git pull`
1. Note that you can `git checkout main`

### DoD
For requester to complete:
- [x] All acceptance criteria are met
~- [ ] New logic has been documented~
~- [ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
