### PR TITLE
#52 Investigate the updater's git resource use

### DIFF
--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -12,7 +12,9 @@ if [ "$CRON_UPDATER" = "true" ]; then
     else
         git pull
         git checkout main
-        git pull
+        # Get the repo history to avoid to following error when pushing large commits
+        # error: pack-objects died of signal 9
+        git fetch --unshallow
     fi
 
     # Update API


### PR DESCRIPTION
Resolves #52

When trying to `git push` large changes of the ~45,000 JSON files, git runs out of memory.

Let's attempt to solve this by using this method: https://stackoverflow.com/a/36189893

### Acceptance Criteria
- [x] Nightly updater's `git push` command runs without failing due to resource limits

### Relevant design files
* None

### Testing instructions
1. Bash into a pod after the updater fails and run `git fetch --unshallow`
1. Note that you can now successfully `git push` that night's commit

### DoD
For requester to complete:
- [x] All acceptance criteria are met
~- [ ] New logic has been documented~
~- [ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
