### PR TITLE
#66 Handle XOS timeout

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -24,6 +24,8 @@ ALL_WORKS = os.getenv('ALL_WORKS', 'false').lower() == 'true'
 UPDATE_SEARCH = os.getenv('UPDATE_SEARCH', 'false').lower() == 'true'
 ACMI_API_ENDPOINT = os.getenv('ACMI_API_ENDPOINT', 'https://api.acmi.net.au')
 XOS_API_ENDPOINT = os.getenv('XOS_API_ENDPOINT', None)
+XOS_RETRIES = int(os.getenv('XOS_RETRIES', '3'))
+XOS_TIMEOUT = int(os.getenv('XOS_TIMEOUT', '60'))
 SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
 JSON_ROOT = os.path.join(SITE_ROOT, 'json/')
 TSV_ROOT = os.path.join(SITE_ROOT, 'tsv/')
@@ -353,9 +355,9 @@ class XOSAPI():
         if not params:
             params = self.params.copy()
         retries = 0
-        while retries < 3:
+        while retries < XOS_RETRIES:
             try:
-                response = requests.get(url=endpoint, params=params, timeout=30)
+                response = requests.get(url=endpoint, params=params, timeout=XOS_TIMEOUT)
                 response.raise_for_status()
                 return response
             except (
@@ -363,8 +365,13 @@ class XOSAPI():
                 requests.exceptions.ConnectionError,
                 requests.exceptions.ReadTimeout,
             ) as exception:
-                print(f'ERROR: couldn\'t get {endpoint} with exception: {exception}... retrying')
+                print(
+                    f'ERROR: couldn\'t get {endpoint} with params: {params}, '
+                    f'exception: {exception}... retrying',
+                )
                 retries += 1
+                if retries == XOS_RETRIES:
+                    raise exception
         return None
 
     def get_works(self):

--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -24,7 +24,7 @@ if [ "$CRON_UPDATER" = "true" ]; then
     export UPDATE_WORKS=false
 
     # Check for git changes
-    export GIT_DIFF=$(git diff | grep "app/json/works/index.json")
+    export GIT_DIFF=$(git diff | grep "app/json")
     if [ -n "$GIT_DIFF" ]; then
         echo "API updates found..."
         # Commit, and push changes

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import botocore
 import elasticsearch
+import pytest
 import requests
 
 import app.api as acmi_api
@@ -514,14 +515,14 @@ def test_search_api_results_failures():
 
 def test_xos_private_api_retries(tmp_path):
     """
-    Test the XOS private API interface retries 3 times before failing gracefully.
+    Test the XOS private API interface retries 3 times before raising an exception.
     """
     with patch('requests.get', MagicMock(side_effect=requests.exceptions.ReadTimeout)) as mock_get:
         acmi_api.JSON_ROOT = tmp_path
         xos_private_api = XOSAPI()
-        response = xos_private_api.get('works')
-        assert not response
-        assert mock_get.call_count == 3
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            xos_private_api.get('works')
+            assert mock_get.call_count == 3
 
 
 def test_generate_tsv(tmp_path):


### PR DESCRIPTION
Resolves #66

It appears there's a Work (or series of Works) in XOS that are taking longer than 30 seconds to render on the API. Let's add `params` to the debug output, increase the timeout to 60 seconds, and raise the right exception if it continues to fail.

### Acceptance Criteria
- [x] Handle XOS timeout so the original exception is thrown
- [x] Have the updater check for any changes in `app/json` folder rather than just the index

### Relevant design files
* None

### Testing instructions
1. Disconnect from the VPN
1. Set `XOS_TIMEOUT` to `'3'` seconds
1. Start the API: `cd development` and `docker-compose up`
1. Connect to the api: `docker exec -it api ash`
1. Run the updater: `CRON_UPDATER=true ./scripts/update-api.sh`
1. Note that after 3 attempts it raises a timeout exception

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests