### PR TITLE
#68 Handle git argument list too long - attempt 2

### DIFF
--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -2,6 +2,7 @@
 
 if [ "$CRON_UPDATER" = "true" ]; then
     set -e
+    ulimit -s 65536
 
     echo "Starting ACMI public API updater..."
 


### PR DESCRIPTION
Resolves #68

Attempt 1 didn't work, so let's try setting a larger space for command arguments.

### Acceptance Criteria
- [x] Try setting a larger space for command arguments: `ulimit -s 65536`

### Relevant design files
* None

### Testing instructions
1. None