### PR TITLE
#71 Fix not on a branch error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
       - name: Build standard image (cached)
         if: success()
         uses: whoan/docker-build-with-cache-action@v4
@@ -37,7 +40,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: main
     - name: Build Python lint and test
       run: |
         cp config.tmpl.env config.env
@@ -61,7 +67,10 @@ jobs:
       DEPLOY_TAG: staging
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
 
       - name: Login to Docker Hub
         if: success()
@@ -115,7 +124,10 @@ jobs:
       DEPLOY_TAG: production
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
 
       - name: Login to Docker Hub
         if: success()

--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -11,11 +11,9 @@ if [ "$CRON_UPDATER" = "true" ]; then
     if [ "$DRY_RUN" = "true" ]; then
         echo "DRY_RUN Not checking out main branch..."
     else
-        git pull
+        # Sanity check we're on the main branch and up to date
+        git pull origin main
         git checkout main
-        # Get the repo history to avoid to following error when pushing large commits
-        # error: pack-objects died of signal 9
-        git fetch --unshallow
     fi
 
     # Update API


### PR DESCRIPTION
Resolves #71

The ACMI API updater has been failing with the following error:

```python
Starting ACMI public API updater...

You are not currently on a branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>
```

### Acceptance Criteria
- [x] Update GitHub Action to pull the entire history, and use the `main` branch

### Relevant design files
* None

### Testing instructions
1. Note this branch's GitHub Actions still pass
1. After merging, note the updater updates nightly again

### DoD
For requester to complete:
- [x] All acceptance criteria are met