### PR TITLE
#79 Update syntax for Pylint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: github.ref
+          ref: ${{ github.ref }}
       - name: Build standard image (cached)
         if: success()
         uses: whoan/docker-build-with-cache-action@v4
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        ref: github.ref
+        ref: ${{ github.ref }}
     - name: Build Python lint and test
       run: |
         cp config.tmpl.env config.env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: main
+          ref: github.ref
       - name: Build standard image (cached)
         if: success()
         uses: whoan/docker-build-with-cache-action@v4
@@ -37,13 +37,14 @@ jobs:
         uses: andymckay/cancel-action@0.2
 
   build-and-test-python:
+    needs: [build-api]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        ref: main
+        ref: github.ref
     - name: Build Python lint and test
       run: |
         cp config.tmpl.env config.env

--- a/.pylintrc
+++ b/.pylintrc
@@ -60,17 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
         file-ignored,
@@ -78,70 +68,8 @@ disable=print-statement,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape,
         # ACMI entries
-        missing-docstring,
-        no-self-use
+        missing-docstring
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -328,13 +256,6 @@ max-line-length=100
 
 # Maximum number of lines in a module.
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
@@ -561,4 +482,4 @@ min-public-methods=2
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception".
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -24,6 +24,12 @@ class MockResponse:
         return None
 
 
+class NoDataException(Exception):
+    """
+    This exception is raised when we don't have mocked sample data for this request.
+    """
+
+
 def mocked_requests_get(*args, **kwargs):
     if kwargs['url'] == 'https://xos.acmi.net.au/api/works/':
         if kwargs['params'].get('page') == '2':
@@ -41,7 +47,7 @@ def mocked_requests_get(*args, **kwargs):
         with open('tests/data/2.json', 'rb') as json_file:
             return MockResponse(json_file.read(), 200)
 
-    raise Exception("No mocked sample data for request: " + kwargs['url'])
+    raise NoDataException("No mocked sample data for request: " + kwargs['url'])
 
 
 def mock_boto3(_, key):


### PR DESCRIPTION
Resolves #79

Our build is failing because of Pylint updates, so let's update our codebase to get it to pass again.

### Acceptance Criteria
- [x] Subclass `Exception` in tests
- [x] Update `.pylintrc` to remove deprecated settings

### Relevant design files
Add a links to the relevant design files or leave as none.
* None

### Testing instructions
1. Note this branch passes