### PR TITLE
#88 Fetch the whole history before updating

### DIFF
--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -16,6 +16,7 @@ if [ "$CRON_UPDATER" = "true" ]; then
         curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
 
         # Sanity check we're on the main branch and up to date
+        git fetch --unshallow
         git pull origin main
         git checkout main
     fi


### PR DESCRIPTION
Resolves #88

To avoid crashing when trying to run a diff on the updates after the updater script runs, let's fetch the whole history.

### Acceptance Criteria
- [x] Add `git fetch --unshallow` before updating the API to avoid diff crashes

### Testing instructions
Add a list of steps required to test the feature.
1. Note the updater runs without failing on `git push`