### PR TITLE
#97 Pin Flask to v2.x until Pytest updates

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto3
-flask
+flask<3
 flask_restful
 furl
 gunicorn


### PR DESCRIPTION
Resolves #97

Running `make test` results in the error:

```bash
  File "/usr/local/lib/python3.12/site-packages/pytest_flask/fixtures.py", line 6, in <module>
    from flask import _request_ctx_stack
ImportError: cannot import name '_request_ctx_stack' from 'flask' (/usr/local/lib/python3.12/site-packages/flask/__init__.py)
make: *** [Makefile:34: test] Error 1
```

### Acceptance Criteria
- [x] Pin `flask<3` until Pytest is updated to be compatible

### Relevant design files
* None

### Testing instructions
1. Re-build: `make build`
1. Run tests: `docker exec -it api make linttest`

