### PR TITLE
#104 Update docker syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Build Python lint and test
       run: |
         cp config.tmpl.env config.env
-        cd development && docker-compose -f docker-compose-base.yml up --build -d
+        cd development && docker compose -f docker-compose-base.yml up --build -d
 
     - name: Run Python lint and test
       run: docker exec api make linttest

--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,16 @@ help:
 	@echo ' linttest         - Run lint and test'
 build:
 	# Build and start the api and search containers
-	cd development && docker-compose up --build
+	cd development && docker compose up --build
 up:
 	# Start the api and search containers
-	cd development && docker-compose up
+	cd development && docker compose up
 base:
 	# Start only the api container
-	cd development && docker-compose -f docker-compose-base.yml up
+	cd development && docker compose -f docker-compose-base.yml up
 down:
 	# Remove the networks
-	cd development && docker-compose down
+	cd development && docker compose down
 lint:
 	# Lint the python code
 	pylint *

--- a/development/docker-compose-base.yml
+++ b/development/docker-compose-base.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   api:
     build:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   api:
     extends:


### PR DESCRIPTION
Resolves #104

Let's update the deprecated docker syntax to fix the build.

### Acceptance Criteria
- [x] Update `docker-compose` to `docker compose` and remove the version number from the yml files

### Relevant design files
* None

### Testing instructions
1. Note the build is fixed again.
1. Note you can still build `make build`