### PR TITLE
#112 Remove old suggestions database at boot

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -26,6 +26,10 @@ rm litestream-v0.3.13-linux-amd64.tar.gz
 export LITESTREAM_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
 export LITESTREAM_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 
+# Ensure the instance directory exists and is empty
+rm -rf /code/app/instance
+mkdir -p /code/app/instance
+
 # Download the latest database from S3
 echo "Downloading latest database from S3..."
 litestream restore -o /code/app/instance/${SUGGESTIONS_DATABASE}.db s3://acmi-public-api/${SUGGESTIONS_DATABASE}.db


### PR DESCRIPTION
Resolves #112

Small bug fix for the suggestions API database to avoid loading an old database at boot.

### Acceptance Criteria
- [x] Remove old suggestions API databases at boot before downloading the latest version from S3

### Relevant design files
* None

### Testing instructions
1. Re-build the app: `make build`
1. Note your database matches `development`: https://api-stg.acmi.net.au/suggestions/