### PR TITLE
#114 Pin elasticsearch to v8 until we upgrade our cloud service to v9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,6 @@ gunicorn
 pytz
 requests
 sentry-sdk[flask]
-elasticsearch
+elasticsearch<9
 setuptools
 Flask-SQLAlchemy


### PR DESCRIPTION
Resolves #114

Let's get ICT to upgrade our ElasticCloud service to elasticsearch v9.

### Acceptance Criteria
- [x] Pin elasticsearch to `v8` until we upgrade our cloud service to `v9`

### Relevant design files
* None

### Testing instructions
1. Build with `make build`
1. Note you can search again: http://localhost:8081/search/?query=hello