### PR TITLE
#116 Upgrade to elasticsearch v9

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         condition: service_healthy
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.2
     hostname: api-search
     container_name: api-search
     restart: on-failure

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,6 @@ gunicorn
 pytz
 requests
 sentry-sdk[flask]
-elasticsearch<9
+elasticsearch
 setuptools
 Flask-SQLAlchemy


### PR DESCRIPTION
Resolves #116

Upgrade elasticsearch to `v9`.

### Acceptance Criteria
- [x] Upgrade to `elasticsearch` `v9` now that we've upgraded our cloud instance

### Relevant design files
* None

### Testing instructions
1. Re-build your containers with `DEBUG=true` in your `config.env`: `make build`
1. Connect to a Python shell: `docker exec -it api python`
1. Inside that shell run: `from app.api import Search` and `Search().update_index('works')`