### PR TITLE
#125 Add JSON-LD

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,31 @@ This API server exposes the following routes:
 * `/works/` - a list of all public ACMI Work records
 * `/works/<id>/` - an individual ACMI Work record
 
+## Linked Art
+
+Individual Work and Creator records are also available as [Linked Art](https://linked.art) JSON-LD, a CIDOC-CRM based linked data profile used by art museums to publish interoperable collection data.
+
+Request the Linked Art representation of a record either by content negotiation:
+
+```bash
+curl -H 'Accept: application/ld+json;profile="https://linked.art/ns/v1/linked-art.json"' https://api.acmi.net.au/works/116936/
+```
+
+or with a query string argument:
+
+```bash
+curl https://api.acmi.net.au/works/116936/?format=linked-art
+curl https://api.acmi.net.au/creators/34373/?format=linked-art
+```
+
+How ACMI records map to Linked Art:
+
+* Works (films, TV shows, videogames etc.) become conceptual `VisualItem` records; Works of type `Object` become physical `HumanMadeObject` records
+* Work titles, ACMI identifiers, types, descriptions and production details (dates, places, creators and their roles) are expressed using [Getty AAT](https://www.getty.edu/research/tools/vocabularies/aat/) classifications
+* Creators become `Person` or `Group` records, with Wikidata links expressed via `equivalent`
+
+The transformation lives in `app/linked_art.py`. Production place URIs (e.g. `/places/<id>/`) and constellation `Set` records don't dereference yet - they're planned for a future phase, along with an [Activity Streams](https://linked.art/api/1.0/hal/) change feed for harvesters.
+
 ## Updating
 
 This repository includes a cron job to update itself automatically each night. The job runs the updater script `/scripts/update-api.sh`, which runs:

--- a/app/api.py
+++ b/app/api.py
@@ -24,6 +24,7 @@ from flask_sqlalchemy import SQLAlchemy
 from furl import furl
 from requests.utils import requote_uri
 
+from app import linked_art
 from app.jira import Client
 
 DEBUG = os.getenv('DEBUG', 'false').lower() == 'true'
@@ -79,6 +80,16 @@ s3_resource = boto3.resource(
     aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
 )
 destination_bucket = s3_resource.Bucket(AWS_STORAGE_BUCKET_NAME)
+
+
+@application.after_request
+def add_cors_header(response):
+    """
+    Allow browser-based clients on other domains to read API responses.
+    Required by the Linked Art protocol: https://linked.art/api/1.0/protocol/
+    """
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    return response
 
 
 class API(Resource):
@@ -278,7 +289,10 @@ class CreatorAPI(Resource):  # pylint: disable=too-few-public-methods
                 f'{int(creator_id)}.json',
             )
             with open(json_file_path, 'rb') as json_file:
-                return json.load(json_file)
+                creator = json.load(json_file)
+            if linked_art.requested():
+                return linked_art.linked_art_response(linked_art.creator_to_linked_art(creator))
+            return creator
         except (FileNotFoundError, ValueError):
             message = f'Creator ID {creator_id} doesn\'t exist, sorry.'
             sentry.capture_message(f'Creators API: {message}')
@@ -320,7 +334,10 @@ class WorkAPI(Resource):  # pylint: disable=too-few-public-methods
         try:
             json_file_path = os.path.join(JSON_ROOT, 'works', f'{int(work_id)}.json')
             with open(json_file_path, 'rb') as json_file:
-                return json.load(json_file)
+                work = json.load(json_file)
+            if linked_art.requested():
+                return linked_art.linked_art_response(linked_art.work_to_linked_art(work))
+            return work
         except (FileNotFoundError, ValueError):
             message = f'Work ID {work_id} doesn\'t exist, sorry.'
             sentry.capture_message(f'Works API: {message}')

--- a/app/linked_art.py
+++ b/app/linked_art.py
@@ -1,0 +1,355 @@
+"""
+Linked Art JSON-LD representations of ACMI Public API records.
+
+Transforms Work and Creator JSON into Linked Art 1.0 records as described
+at https://linked.art/api/1.0/ and serves them via content negotiation
+(Accept: application/ld+json) or the ?format=linked-art query string.
+"""
+
+import html
+import json
+import os
+import re
+
+from flask import Response, request
+
+ACMI_API_ENDPOINT = os.getenv('ACMI_API_ENDPOINT', 'https://api.acmi.net.au')
+LINKED_ART_CONTEXT = 'https://linked.art/ns/v1/linked-art.json'
+LINKED_ART_MEDIA_TYPE = f'application/ld+json;profile="{LINKED_ART_CONTEXT}"'
+LINKED_ART_FORMATS = ['linked-art', 'jsonld', 'json-ld']
+GETTY_AAT_ENDPOINT = 'http://vocab.getty.edu/aat/'
+WIKIDATA_ENTITY_ENDPOINT = 'http://www.wikidata.org/entity/'
+
+# Work types that are physical objects rather than conceptual/visual works.
+PHYSICAL_WORK_TYPES = ['Object']
+
+# Creator roles performed by organisations rather than individual people.
+ORGANISATION_ROLES = [
+    'production company',
+    'distributor',
+    'production facilities',
+    'funding',
+    'publisher',
+    'support',
+    'partner',
+]
+
+# Getty AAT concepts for ACMI work types, verified against vocab.getty.edu.
+# Music videos have no AAT concept, so use the broader moving images concept.
+WORK_TYPE_CONCEPTS = {
+    'Film': [('300136900', 'motion pictures (visual works)')],
+    'TV show': [('300263432', 'television programs')],
+    'Videogame': [('300256888', 'video games')],
+    'Website': [('300265431', 'Web sites')],
+    'Artwork': [('300133025', 'works of art')],
+    'Video': [('300263857', 'moving images')],
+    'Music video': [('300263857', 'moving images')],
+}
+
+# Getty AAT concepts for ACMI creator roles, verified against vocab.getty.edu.
+# Unmapped roles fall back to a human-readable label on the creation event.
+ROLE_CONCEPTS = {
+    'director': [('300025654', 'directors')],
+    'co-director': [('300025654', 'directors')],
+    'producer': [('300197742', 'producers')],
+    'co-producer': [('300197742', 'producers')],
+    'executive producer': [('300197742', 'producers')],
+    'producer/director': [('300197742', 'producers'), ('300025654', 'directors')],
+    'co-producers/directors': [('300197742', 'producers'), ('300025654', 'directors')],
+    'production company': [('300419391', 'production companies')],
+    'distributor': [('300404885', 'distributors')],
+    'editor': [('300386237', 'film editors')],
+    'writer': [('300025515', 'screen writers')],
+    'cinematographer': [('300025650', 'cinematographers')],
+    'publisher': [('300025574', 'publishers')],
+    'photographer': [('300025687', 'photographers')],
+    'narrator': [('300417254', 'narrators')],
+}
+
+
+def aat_type(aat_id, label):
+    """
+    Return a reference to a Getty AAT concept.
+    """
+    return {
+        'id': f'{GETTY_AAT_ENDPOINT}{aat_id}',
+        'type': 'Type',
+        '_label': label,
+    }
+
+
+def strip_html(text):
+    """
+    Remove HTML tags and entities, and collapse whitespace in a text field.
+    """
+    text = re.sub(r'<[^>]+>', ' ', text)
+    text = html.unescape(text)
+    return re.sub(r'\s+', ' ', text).strip()
+
+
+def year_of(date_string):
+    """
+    Return the year from a date string (e.g. 2004 from 2004-01-01T11:00:00+11:00), or None.
+    """
+    match = re.match(r'(\d{4})', str(date_string or ''))
+    return int(match.group(1)) if match else None
+
+
+def timespan(begin_year, end_year=None):
+    """
+    Return a Linked Art TimeSpan covering whole years.
+    """
+    if not end_year:
+        end_year = begin_year
+    return {
+        'type': 'TimeSpan',
+        'begin_of_the_begin': f'{begin_year}-01-01T00:00:00Z',
+        'end_of_the_end': f'{end_year}-12-31T23:59:59Z',
+    }
+
+
+def requested():
+    """
+    Returns True if the current request asks for a Linked Art response, either
+    via the Accept header or a format= query string argument.
+    """
+    if request.args.get('format', '').lower() in LINKED_ART_FORMATS:
+        return True
+    return 'application/ld+json' in request.headers.get('Accept', '')
+
+
+def linked_art_response(record):
+    """
+    Serialise a Linked Art record with the JSON-LD media type and profile.
+    """
+    return Response(
+        json.dumps(record, indent=2, ensure_ascii=False),
+        content_type=LINKED_ART_MEDIA_TYPE,
+    )
+
+
+def primary_name(content):
+    """
+    Return a Name classified as a Primary Name.
+    """
+    return {
+        'type': 'Name',
+        'classified_as': [aat_type('300404670', 'Primary Name')],
+        'content': content,
+    }
+
+
+def statement(content, classification):
+    """
+    Return a human-readable statement (LinguisticObject) with the given classification.
+    """
+    return {
+        'type': 'LinguisticObject',
+        'classified_as': [classification],
+        'content': strip_html(content),
+    }
+
+
+def actor_reference(creator_role):
+    """
+    Return a Person or Group reference for a creator role entry on a Work,
+    or None if the creator doesn't have its own API record.
+    """
+    creator_id = creator_role.get('creator_id')
+    if not creator_id:
+        return None
+    actor_type = 'Group' if creator_role.get('role') in ORGANISATION_ROLES else 'Person'
+    return {
+        'id': f'{ACMI_API_ENDPOINT}/creators/{creator_id}/',
+        'type': actor_type,
+        '_label': creator_role.get('name'),
+    }
+
+
+def creation_event(work, event_type):
+    """
+    Return the Creation/Production event for a Work, or None if there's no
+    date, place or creator information to include.
+    """
+    event = {'type': event_type}
+
+    begin_year = year_of(work.get('first_production_date'))
+    end_year = None
+    for production_date in work.get('production_dates') or []:
+        end_year = year_of(production_date.get('to_year'))
+        if end_year:
+            break
+    if begin_year:
+        event['timespan'] = timespan(begin_year, end_year)
+
+    places = []
+    for place in work.get('production_places') or []:
+        if place.get('id'):
+            places.append({
+                'id': f'{ACMI_API_ENDPOINT}/places/{place["id"]}/',
+                'type': 'Place',
+                '_label': place.get('name'),
+            })
+    if places:
+        event['took_place_at'] = places
+
+    parts = []
+    creator_roles = (work.get('creators_primary') or []) + (work.get('creators_other') or [])
+    for creator_role in creator_roles:
+        actor = actor_reference(creator_role)
+        if not actor:
+            continue
+        part = {
+            'type': event_type,
+            'carried_out_by': [actor],
+        }
+        role = creator_role.get('role')
+        role_concepts = ROLE_CONCEPTS.get(role)
+        if role_concepts:
+            part['classified_as'] = [aat_type(*concept) for concept in role_concepts]
+        elif role:
+            part['_label'] = role
+        parts.append(part)
+    if parts:
+        event['part'] = parts
+
+    if len(event) == 1:
+        return None
+    return event
+
+
+def work_to_linked_art(work):
+    """
+    Return the Linked Art representation of an ACMI Work.
+
+    Most ACMI works are moving image works (films, TV shows, videogames),
+    which Linked Art models as conceptual VisualItem records; works of
+    type Object are physical items, modelled as HumanMadeObject records.
+    """
+    physical = work.get('type') in PHYSICAL_WORK_TYPES
+    record = {
+        '@context': LINKED_ART_CONTEXT,
+        'id': f'{ACMI_API_ENDPOINT}/works/{work.get("id")}/',
+        'type': 'HumanMadeObject' if physical else 'VisualItem',
+    }
+    if work.get('title'):
+        record['_label'] = work['title']
+
+    identifiers = []
+    if work.get('title'):
+        identifiers.append(primary_name(work['title']))
+    if work.get('acmi_id'):
+        identifiers.append({
+            'type': 'Identifier',
+            'classified_as': [aat_type('300312355', 'Accession Number')],
+            'content': work['acmi_id'],
+        })
+    if identifiers:
+        record['identified_by'] = identifiers
+
+    work_type_concepts = WORK_TYPE_CONCEPTS.get(work.get('type'))
+    if work_type_concepts:
+        record['classified_as'] = [aat_type(*concept) for concept in work_type_concepts]
+
+    statements = []
+    for field in ['brief_description', 'description']:
+        if work.get(field):
+            description = statement(work[field], aat_type('300435416', 'Description'))
+            if description['content'] and description not in statements:
+                statements.append(description)
+    if statements:
+        record['referred_to_by'] = statements
+
+    event = creation_event(work, 'Production' if physical else 'Creation')
+    if event:
+        record['produced_by' if physical else 'created_by'] = event
+
+    part_of = work.get('part_of')
+    if part_of and part_of.get('id'):
+        record['part_of'] = [{
+            'id': f'{ACMI_API_ENDPOINT}/works/{part_of["id"]}/',
+            'type': record['type'],
+            '_label': part_of.get('title'),
+        }]
+
+    return record
+
+
+def creator_type(creator):
+    """
+    Returns Person or Group for a Creator record. Birth, death and gender
+    data only exist for people; failing that, creators whose roles are all
+    organisational (e.g. production company) are treated as a Group.
+    """
+    if creator.get('date_of_birth') or creator.get('date_of_death') or creator.get('genders'):
+        return 'Person'
+    roles = {role.get('role') for role in creator.get('roles_in_work') or []}
+    if roles and all(role in ORGANISATION_ROLES for role in roles):
+        return 'Group'
+    return 'Person'
+
+
+def creator_to_linked_art(creator):
+    """
+    Return the Linked Art representation of an ACMI Creator.
+    """
+    record = {
+        '@context': LINKED_ART_CONTEXT,
+        'id': f'{ACMI_API_ENDPOINT}/creators/{creator.get("id")}/',
+        'type': creator_type(creator),
+    }
+    if creator.get('name'):
+        record['_label'] = creator['name']
+
+    identifiers = []
+    if creator.get('name'):
+        identifiers.append(primary_name(creator['name']))
+    if creator.get('also_known_as'):
+        identifiers.append({
+            'type': 'Name',
+            'content': creator['also_known_as'],
+        })
+    if identifiers:
+        record['identified_by'] = identifiers
+
+    if creator.get('biography'):
+        biography = statement(creator['biography'], aat_type('300435422', 'Biography Statement'))
+        if biography['content']:
+            record['referred_to_by'] = [biography]
+
+    if record['type'] == 'Person':
+        if creator.get('date_of_birth'):
+            record['born'] = {
+                'type': 'Birth',
+                'timespan': day_timespan(creator['date_of_birth']),
+            }
+        if creator.get('date_of_death'):
+            record['died'] = {
+                'type': 'Death',
+                'timespan': day_timespan(creator['date_of_death']),
+            }
+
+    equivalents = []
+    for reference in creator.get('external_references') or []:
+        source = reference.get('source') or {}
+        if source.get('slug') == 'wikidata' and reference.get('source_identifier'):
+            equivalents.append({
+                'id': f'{WIKIDATA_ENTITY_ENDPOINT}{reference["source_identifier"]}',
+                'type': record['type'],
+                '_label': creator.get('name'),
+            })
+    if equivalents:
+        record['equivalent'] = equivalents
+
+    return record
+
+
+def day_timespan(date_string):
+    """
+    Return a Linked Art TimeSpan covering a single day (e.g. a date of birth).
+    """
+    return {
+        'type': 'TimeSpan',
+        'begin_of_the_begin': f'{date_string}T00:00:00Z',
+        'end_of_the_end': f'{date_string}T23:59:59Z',
+    }

--- a/tests/data/linked_art_work.json
+++ b/tests/data/linked_art_work.json
@@ -1,0 +1,64 @@
+{
+  "id": 116936,
+  "acmi_id": "B2001950",
+  "title": "Love My Way: Only Mortal",
+  "slug": "love-my-way-only-mortal",
+  "record_type": "work",
+  "type": "TV show",
+  "brief_description": "<p>The groundbreaking, multiple award-winning drama series &#8216;Love My Way&#8217; was one of the first Australian productions made exclusively for subscription television.</p>",
+  "first_production_date": "2004-01-01T11:00:00+11:00",
+  "production_dates": [
+    {
+      "date": "2004",
+      "notes": "",
+      "to_year": "2005"
+    }
+  ],
+  "production_places": [
+    {
+      "id": 3,
+      "name": "Australia",
+      "slug": "australia"
+    }
+  ],
+  "creators_primary": [
+    {
+      "id": 2654883,
+      "name": "Jessica Hobbs",
+      "creator_id": 83676,
+      "creator_wikidata_id": "Q106240689",
+      "role": "director",
+      "role_id": 938,
+      "is_primary": true
+    },
+    {
+      "id": 2654877,
+      "name": "Foxtel",
+      "creator_id": 83675,
+      "creator_wikidata_id": "Q121034294",
+      "role": "production company",
+      "role_id": 941,
+      "is_primary": true
+    }
+  ],
+  "creators_other": [
+    {
+      "id": 2654999,
+      "name": "Unlinked Creator",
+      "creator_id": null,
+      "creator_wikidata_id": null,
+      "role": "best boy",
+      "role_id": 999,
+      "is_primary": false
+    }
+  ],
+  "part_of": null,
+  "parts": [],
+  "group": null,
+  "labels": [],
+  "source": {
+    "name": "Vernon",
+    "slug": "vernon"
+  },
+  "source_identifier": "108414"
+}

--- a/tests/linked_art_tests.py
+++ b/tests/linked_art_tests.py
@@ -1,0 +1,250 @@
+import json
+from unittest.mock import mock_open, patch
+
+import app.api as acmi_api
+from app import linked_art
+
+
+def load_json(file_path):
+    """
+    Load JSON test data from the filesystem.
+    """
+    with open(file_path, 'rb') as json_file:
+        return json.load(json_file)
+
+
+def mock_work():
+    """
+    Mocked individual Work json data.
+    """
+    with open('tests/data/linked_art_work.json', 'rb') as json_file:
+        return mock_open(read_data=json_file.read())
+
+
+def mock_creator():
+    """
+    Mocked individual Creator json data.
+    """
+    with open('tests/data/creator_34373.json', 'rb') as json_file:
+        return mock_open(read_data=json_file.read())
+
+
+def test_work_to_linked_art():
+    """
+    Test a Work is transformed to a valid Linked Art VisualItem record.
+    """
+    work = load_json('tests/data/linked_art_work.json')
+    record = linked_art.work_to_linked_art(work)
+
+    assert record['@context'] == 'https://linked.art/ns/v1/linked-art.json'
+    assert record['id'] == 'https://api.acmi.net.au/works/116936/'
+    assert record['type'] == 'VisualItem'
+    assert record['_label'] == 'Love My Way: Only Mortal'
+
+    names = [item for item in record['identified_by'] if item['type'] == 'Name']
+    identifiers = [item for item in record['identified_by'] if item['type'] == 'Identifier']
+    assert names[0]['content'] == 'Love My Way: Only Mortal'
+    assert names[0]['classified_as'][0]['id'] == 'http://vocab.getty.edu/aat/300404670'
+    assert identifiers[0]['content'] == 'B2001950'
+    assert identifiers[0]['classified_as'][0]['id'] == 'http://vocab.getty.edu/aat/300312355'
+
+    assert record['classified_as'][0]['id'] == 'http://vocab.getty.edu/aat/300263432'
+    assert record['classified_as'][0]['_label'] == 'television programs'
+
+    description = record['referred_to_by'][0]
+    assert description['type'] == 'LinguisticObject'
+    assert description['classified_as'][0]['id'] == 'http://vocab.getty.edu/aat/300435416'
+    assert '<p>' not in description['content']
+    assert '&#8216;' not in description['content']
+    assert description['content'].startswith('The groundbreaking')
+    assert '‘Love My Way’' in description['content']
+
+
+def test_work_to_linked_art_creation():
+    """
+    Test the Creation event of a Linked Art Work record.
+    """
+    work = load_json('tests/data/linked_art_work.json')
+    creation = linked_art.work_to_linked_art(work)['created_by']
+
+    assert creation['type'] == 'Creation'
+    assert creation['timespan']['begin_of_the_begin'] == '2004-01-01T00:00:00Z'
+    assert creation['timespan']['end_of_the_end'] == '2005-12-31T23:59:59Z'
+    assert creation['took_place_at'][0]['id'] == 'https://api.acmi.net.au/places/3/'
+    assert creation['took_place_at'][0]['_label'] == 'Australia'
+
+    assert len(creation['part']) == 2, 'Creators without their own API record should be skipped'
+    director, production_company = creation['part']
+    assert director['carried_out_by'][0]['id'] == 'https://api.acmi.net.au/creators/83676/'
+    assert director['carried_out_by'][0]['type'] == 'Person'
+    assert director['classified_as'][0]['id'] == 'http://vocab.getty.edu/aat/300025654'
+    assert production_company['carried_out_by'][0]['type'] == 'Group'
+    assert production_company['classified_as'][0]['id'] == 'http://vocab.getty.edu/aat/300419391'
+
+
+def test_physical_work_to_linked_art():
+    """
+    Test Works of type Object become HumanMadeObject records with a Production event.
+    """
+    work = {
+        'id': 1,
+        'title': 'Bell & Howell Filmo camera',
+        'type': 'Object',
+        'first_production_date': '1923-01-01T00:00:00+11:00',
+        'creators_primary': [
+            {'name': 'Bell & Howell', 'creator_id': 2, 'role': 'production company'},
+        ],
+    }
+    record = linked_art.work_to_linked_art(work)
+    assert record['type'] == 'HumanMadeObject'
+    assert 'created_by' not in record
+    assert record['produced_by']['type'] == 'Production'
+    assert record['produced_by']['part'][0]['type'] == 'Production'
+
+
+def test_work_part_of():
+    """
+    Test a Work that is part of another Work links to its parent.
+    """
+    work = {
+        'id': 2,
+        'title': 'Episode one',
+        'type': 'TV show',
+        'part_of': {'id': 3, 'title': 'The series'},
+    }
+    record = linked_art.work_to_linked_art(work)
+    assert record['part_of'][0]['id'] == 'https://api.acmi.net.au/works/3/'
+    assert record['part_of'][0]['type'] == 'VisualItem'
+    assert record['part_of'][0]['_label'] == 'The series'
+
+
+def test_minimal_work_to_linked_art():
+    """
+    Test a Work with minimal data still produces a valid record.
+    """
+    record = linked_art.work_to_linked_art({'id': 1})
+    assert record['@context'] == 'https://linked.art/ns/v1/linked-art.json'
+    assert record['id'] == 'https://api.acmi.net.au/works/1/'
+    assert record['type'] == 'VisualItem'
+    optional_keys = [
+        '_label', 'identified_by', 'classified_as', 'referred_to_by', 'created_by', 'part_of',
+    ]
+    for key in optional_keys:
+        assert key not in record
+
+
+def test_creator_to_linked_art():
+    """
+    Test a Creator is transformed to a valid Linked Art Person record.
+    """
+    creator = load_json('tests/data/creator_34373.json')
+    record = linked_art.creator_to_linked_art(creator)
+
+    assert record['@context'] == 'https://linked.art/ns/v1/linked-art.json'
+    assert record['id'] == 'https://api.acmi.net.au/creators/34373/'
+    assert record['type'] == 'Person'
+    assert record['_label'] == 'Agnes Varda'
+
+    primary_name, alternate_name = record['identified_by']
+    assert primary_name['content'] == 'Agnes Varda'
+    assert primary_name['classified_as'][0]['id'] == 'http://vocab.getty.edu/aat/300404670'
+    assert alternate_name['content'] == 'Arlette Varda'
+
+    biography = record['referred_to_by'][0]
+    assert biography['classified_as'][0]['id'] == 'http://vocab.getty.edu/aat/300435422'
+    assert record['born']['timespan']['begin_of_the_begin'] == '1928-05-30T00:00:00Z'
+    assert record['died']['timespan']['begin_of_the_begin'] == '2019-03-29T00:00:00Z'
+    assert record['equivalent'][0]['id'] == 'http://www.wikidata.org/entity/Q229990'
+    assert record['equivalent'][0]['type'] == 'Person'
+
+
+def test_organisation_to_linked_art():
+    """
+    Test a Creator whose roles are all organisational becomes a Group record.
+    """
+    creator = {
+        'id': 83675,
+        'name': 'Foxtel',
+        'date_of_birth': None,
+        'genders': [],
+        'roles_in_work': [
+            {'role': 'production company'},
+            {'role': 'distributor'},
+        ],
+    }
+    record = linked_art.creator_to_linked_art(creator)
+    assert record['type'] == 'Group'
+    assert 'born' not in record
+    assert 'died' not in record
+
+
+def test_creator_type_defaults_to_person():
+    """
+    Test Creators without birth, death, gender or organisational role data become a Person.
+    """
+    assert linked_art.creator_type({'roles_in_work': [{'role': 'director'}]}) == 'Person'
+    assert linked_art.creator_type({}) == 'Person'
+
+
+@patch('builtins.open', mock_work())
+def test_work_api_linked_art_format():
+    """
+    Test the Work API returns Linked Art JSON-LD for the format= argument.
+    """
+    with acmi_api.application.test_client() as client:
+        response = client.get('/works/116936/?format=linked-art')
+        assert response.status_code == 200
+        assert response.content_type == linked_art.LINKED_ART_MEDIA_TYPE
+        assert response.json['@context'] == 'https://linked.art/ns/v1/linked-art.json'
+        assert response.json['type'] == 'VisualItem'
+
+
+@patch('builtins.open', mock_work())
+def test_work_api_linked_art_accept_header():
+    """
+    Test the Work API returns Linked Art JSON-LD via content negotiation.
+    """
+    with acmi_api.application.test_client() as client:
+        response = client.get(
+            '/works/116936/',
+            headers={'Accept': linked_art.LINKED_ART_MEDIA_TYPE},
+        )
+        assert response.status_code == 200
+        assert response.content_type == linked_art.LINKED_ART_MEDIA_TYPE
+        assert response.json['id'] == 'https://api.acmi.net.au/works/116936/'
+
+
+@patch('builtins.open', mock_work())
+def test_work_api_default_format_unchanged():
+    """
+    Test the Work API still returns ACMI JSON by default.
+    """
+    with acmi_api.application.test_client() as client:
+        response = client.get('/works/116936/', content_type='application/json')
+        assert response.status_code == 200
+        assert response.content_type == 'application/json'
+        assert '@context' not in response.json
+        assert response.json['acmi_id'] == 'B2001950'
+
+
+@patch('builtins.open', mock_creator())
+def test_creator_api_linked_art_format():
+    """
+    Test the Creator API returns Linked Art JSON-LD for the format= argument.
+    """
+    with acmi_api.application.test_client() as client:
+        response = client.get('/creators/34373/?format=linked-art')
+        assert response.status_code == 200
+        assert response.content_type == linked_art.LINKED_ART_MEDIA_TYPE
+        assert response.json['type'] == 'Person'
+        assert response.json['_label'] == 'Agnes Varda'
+
+
+@patch('builtins.open', mock_work())
+def test_cors_header():
+    """
+    Test responses include the open CORS header required by Linked Art.
+    """
+    with acmi_api.application.test_client() as client:
+        response = client.get('/works/116936/')
+        assert response.headers['Access-Control-Allow-Origin'] == '*'


### PR DESCRIPTION
Resolves #125

Let's add the ability to return `JSON-LD` format API responses.

### Acceptance Criteria
- [x] Add support for `JSON-LD` conforming to [linked.art](https://linked.art) v1.0

### Relevant design files
* None

### Testing instructions
1. Re-build locally: `make base`
1. Request a work in `JSON-LD` format: http://localhost:8081/works/109678/?format=jsonld